### PR TITLE
calculate perplexity score per epoch

### DIFF
--- a/src/gretel_synthetics/model.py
+++ b/src/gretel_synthetics/model.py
@@ -3,12 +3,21 @@ Tensorflow - Keras Sequential RNN (GRU)
 """
 import logging
 
+from tensorflow.keras import backend as K
 from tensorflow.keras.optimizers import RMSprop
 import tensorflow as tf
 from tensorflow_privacy.privacy.optimizers.dp_optimizer import make_gaussian_optimizer_class as make_dp_optimizer
 from tensorflow_privacy.privacy.analysis import compute_dp_sgd_privacy
 
 from gretel_synthetics.config import BaseConfig
+
+
+def perplexity(true_label, pred_label):
+    """
+    callback to compute model perplexity as training metric
+    """
+    cross_entropy = K.sparse_categorical_crossentropy(true_label, pred_label, from_logits=True)
+    return K.exp(cross_entropy)
 
 
 def build_sequential_model(vocab_size: int, batch_size: int, store: BaseConfig) -> tf.keras.Sequential:
@@ -57,7 +66,8 @@ def build_sequential_model(vocab_size: int, batch_size: int, store: BaseConfig) 
         loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
 
     logging.info(model.summary())
-    model.compile(optimizer=optimizer, loss=loss, metrics=['accuracy'])
+    model.compile(optimizer=optimizer, loss=loss, metrics=['accuracy',
+                                                           perplexity])
     return model
 
 


### PR DESCRIPTION
Adding perplexity score to help estimate model performance

```
Train for 13 steps
Epoch 1/5
13/13 [==============================] - 15s 1s/step - loss: 8.9449 - accuracy: 0.1634 - perplexity: 97261888.0000
Epoch 2/5
13/13 [==============================] - 13s 1s/step - loss: 6.7920 - accuracy: 0.2087 - perplexity: 2790627.0000
Epoch 3/5
13/13 [==============================] - 13s 1s/step - loss: 6.6451 - accuracy: 0.2062 - perplexity: 338934.9375
Epoch 4/5
13/13 [==============================] - 13s 1s/step - loss: 6.6424 - accuracy: 0.2403 - perplexity: 151582.2969
Epoch 5/5
13/13 [==============================] - 13s 1s/step - loss: 6.6355 - accuracy: 0.2117 - perplexity: 101105.3750
```
