### PR TITLE
Added read and write modes for batch interface

### DIFF
--- a/examples/dataframe_batch.ipynb
+++ b/examples/dataframe_batch.ipynb
@@ -65,7 +65,7 @@
     "config_template = {\n",
     "    \"max_lines\": 0,\n",
     "    \"max_line_len\": 2048,\n",
-    "    \"epochs\": 5,\n",
+    "    \"epochs\": 15,\n",
     "    \"vocab_size\": 20000,\n",
     "    \"gen_lines\": 100,\n",
     "    \"dp\": True,\n",

--- a/examples/dataframe_batch.ipynb
+++ b/examples/dataframe_batch.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,16 +60,18 @@
    "source": [
     "from pathlib import Path\n",
     "\n",
+    "checkpoint_dir = str(Path.cwd() / \"checkpoints\")\n",
+    "\n",
     "config_template = {\n",
     "    \"max_lines\": 0,\n",
     "    \"max_line_len\": 2048,\n",
-    "    \"epochs\": 15,\n",
+    "    \"epochs\": 5,\n",
     "    \"vocab_size\": 20000,\n",
     "    \"gen_lines\": 100,\n",
     "    \"dp\": True,\n",
     "    \"field_delimiter\": \",\",\n",
     "    \"overwrite\": True,\n",
-    "    \"checkpoint_dir\": str(Path.cwd() / \"checkpoints\")\n",
+    "    \"checkpoint_dir\": checkpoint_dir\n",
     "}"
    ]
   },
@@ -151,6 +153,44 @@
    "source": [
     "# Finally, we can re-assemble all synthetic batches into our new synthetic DF\n",
     "batcher.batches_to_df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Read only mode\n",
+    "\n",
+    "If you've already created a model(s) and simply want to load that data to generate more lines, you can use the read-only mode for the batch interface. No input DataFrame is required and it will automatically try and load model information from a primary checkpoint directory.\n",
+    "\n",
+    "Additionally, you can also control the number of lines you wish to generate with the ``num_lines`` parameter for generation. This option exists for write mode as well and overrides the number of lines specified in the synthetic config that was used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "read_batch = DataFrameBatch(mode=\"read\", checkpoint_dir=checkpoint_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "read_batch.generate_all_batch_lines(num_lines=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "read_batch.batches_to_df()"
    ]
   }
  ],

--- a/src/gretel_synthetics/config.py
+++ b/src/gretel_synthetics/config.py
@@ -108,7 +108,7 @@ class BaseConfig:
 
     # Training configurations
     max_lines: int = 0
-    epochs: int = 30
+    epochs: int = 15
     batch_size: int = 64
     buffer_size: int = 10000
     seq_length: int = 100
@@ -139,7 +139,7 @@ class BaseConfig:
     gen_lines: int = 1000
 
     # Checkpoint storage
-    save_all_checkpoints: bool = True
+    save_all_checkpoints: bool = False
     overwrite: bool = False
 
     @abstractmethod

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,7 +17,7 @@ def test_local_config(mkdir):
     lc = LocalConfig(checkpoint_dir=target, input_data_path=test_data_file.as_posix())
 
     mkdir.assert_called
-    assert lc.epochs == 30
+    assert lc.epochs == 15
     assert lc.input_data_path == test_data_file.as_posix()
     assert lc.tokenizer_prefix == TOKENIZER_PREFIX
     assert lc.training_data == Path(target, "training_data.txt").as_posix()
@@ -30,7 +30,7 @@ def test_local_config_settings(mkdir):
     check = lc.as_dict()
     assert check == {
         "max_lines": 0,
-        "epochs": 30,
+        "epochs": 15,
         "batch_size": 64,
         "buffer_size": 10000,
         "seq_length": 100,
@@ -49,7 +49,7 @@ def test_local_config_settings(mkdir):
         "gen_chars": 0,
         "gen_lines": 1000,
         "max_line_len": 2048,
-        "save_all_checkpoints": True,
+        "save_all_checkpoints": False,
         "checkpoint_dir": "foo",
         "field_delimiter": None,
         "field_delimiter_token": "<d>",


### PR DESCRIPTION
closes #36 

Created read and write modes for the batch interface. Default behavior (for backwards compat) is write mode and operates exactly the same as before. If you use read mode, then training is disabled, an input DF is not required, only the primary checkpoint location is.

Batch notebook has been updated with usage example