### PR TITLE
SYN-4: Provide quicker feedback from parallel workers

### DIFF
--- a/src/gretel_synthetics/generate_parallel.py
+++ b/src/gretel_synthetics/generate_parallel.py
@@ -111,7 +111,7 @@ def generate_parallel(settings: Settings, num_workers: int, chunks: List[int]):
 
     # Instruct each worker to return an intermediate result (at the cost of putting a partial chunk
     # back into the queue) if it has generated 105% of the requested number of valid lines per chunk
-    # (regardless of how many lines are valid in the intermediate result). This ensures that works
+    # (regardless of how many lines are valid in the intermediate result). This ensures that workers
     # don't get stuck for a long time generating data from bad models, where the ratio of invalid:valid
     # lines is very high.
     max_response_size = int(chunks[0] * 1.05)

--- a/src/gretel_synthetics/generate_parallel.py
+++ b/src/gretel_synthetics/generate_parallel.py
@@ -198,13 +198,13 @@ def _process_all_chunks(settings: Settings,
             chunk_size = input_queue.get_nowait()
             prev_invalid = gen.total_invalid
             all_lines = list(gen.generate_next(chunk_size, hard_limit=max_response_size))
-            num_invalid_lines = gen.total_invalid - prev_invalid
-            if num_invalid_lines:
+            num_valid_lines = len(all_lines) - (gen.total_invalid - prev_invalid)
+            if num_valid_lines < chunk_size:
                 # Return the number of lines by which we fell short to the queue.
                 # This is guaranteed to succeed because every worker will only do this after
                 # at least removing an element from the queue, thus ensuring that capacity
                 # constraints are never violated.
-                input_queue.put_nowait(num_invalid_lines)
+                input_queue.put_nowait(chunk_size - num_valid_lines)
             yield _WorkerStatus(lines=all_lines)
     except queue.Empty:
         # Input queue is pre-filled, so empty queue means we are done with our initially


### PR DESCRIPTION
When a parallel worker processes a chunk, impose a hard limit on the total number of lines equal to 105% of the requested number of valid lines in a full chunk.

Whenever a worker hits that limit when processing a chunk and thus falls short of the requested number of valid lines, we put a chunk for the missing number of valid lines into the queue. Since this only happens after first removing an element from the queue, we can be sure that this will neither block nor fail due to capacity constraints. Likewise, the correctness of shutting down a worker when an empty queue is observed is not impaired, as the number of items that can at most be put pack into the queue concurrently cannot exceed the number of remaining workers.

This ensures better responsiveness of workers when the model is poor and a lot of invalid lines are being generated. Previously, the worker would wait until it had a sufficient number of valid lines generated before communicating an intermediate result back to the parent process.