### PR TITLE
Switch multiprocessing backend to loky

### DIFF
--- a/examples/generate_as_module.py
+++ b/examples/generate_as_module.py
@@ -8,8 +8,6 @@ In the event that you choose to export a Notebook to a pure module, please note 
 changes will have a ``NOTE:`` comment.
 """
 
-# NOTE: Required import for launching from standlone module
-from multiprocessing import freeze_support
 from pathlib import Path
 
 from gretel_synthetics.config import LocalConfig
@@ -72,7 +70,7 @@ def start():
         print(line)
 
 
-# NOTE: Invoke your generation this way
+# NOTE: It is preferred to always invoke your generation this way. Simply invoking start() from
+# the top-level of the main module *should* work, but YMMV.
 if __name__ == "__main__":
-    freeze_support()
     start()

--- a/examples/generate_as_module.py
+++ b/examples/generate_as_module.py
@@ -1,8 +1,9 @@
 
 """
 Example module on how to run data generation from a standlone python invocation. Tensorflow
-requires that processes are launch with "spawn" mode, which requires the use of ``freeze_support()``
-that has to be called in the `__main__` scope of the module.
+requires that processes are launch with "spawn" mode, for which it is a good practice to ensure
+that any code is only executed after checking that we are in the main module
+(`if __name__ == '__main__'`).
 
 In the event that you choose to export a Notebook to a pure module, please note the changes below. These
 changes will have a ``NOTE:`` comment.

--- a/examples/generate_as_module.py
+++ b/examples/generate_as_module.py
@@ -36,7 +36,7 @@ config = LocalConfig(
 
 # Let's generate some text!
 #
-# The ``generate_text`` funtion is a generator that will return
+# The ``generate_text`` function is a generator that will return
 # a line of predicted text based on the ``gen_lines`` setting in your
 # config.
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ smart_open==2.0.0
 pandas>=1.0.0
 numpy>=1.18.0
 tqdm<5.0
-cloudpickle==1.5.0
+loky==2.8.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'pandas>=1.0.0',
         'numpy>=1.18.0',
         'dataclasses==0.7;python_version<"3.7"',
-        'cloudpickle==1.5.0',
+        'loky==2.8.0',
     ],
     extras_require={
         'tf': ['tensorflow==2.1.0']

--- a/src/gretel_synthetics/batch.py
+++ b/src/gretel_synthetics/batch.py
@@ -25,6 +25,7 @@ from tqdm.auto import tqdm
 
 from gretel_synthetics.config import LocalConfig
 from gretel_synthetics.generate import gen_text, generate_text
+from gretel_synthetics.generator import TooManyInvalidError
 from gretel_synthetics.train import train_rnn
 
 
@@ -433,7 +434,7 @@ class DataFrameBatch:
                 else:
                     t2.update(1)
                     batch.gen_data_invalid.append(line)
-        except RuntimeError:
+        except TooManyInvalidError:
             if raise_on_exceed_invalid:
                 raise
             else:

--- a/src/gretel_synthetics/generate.py
+++ b/src/gretel_synthetics/generate.py
@@ -13,7 +13,7 @@ import tensorflow as tf
 
 from gretel_synthetics.generator import Generator, Settings
 from gretel_synthetics.generator import gen_text, PredString  # noqa # pylint: disable=unused-import
-from gretel_synthetics.generate_parallel import split_work, generate_parallel
+from gretel_synthetics.generate_parallel import get_num_workers, generate_parallel
 
 if TYPE_CHECKING:  # pragma: no cover
     from gretel_synthetics.config import LocalConfig
@@ -104,10 +104,10 @@ def generate_text(
     else:
         _line_count = config.gen_lines
 
-    num_workers, chunks = split_work(parallelism, _line_count)
+    num_workers = get_num_workers(parallelism, _line_count, chunk_size=5)
 
     if num_workers == 1:  # Sequential operation
         gen = Generator(settings)
         yield from gen.generate_next(_line_count)
     else:
-        yield from generate_parallel(settings, num_workers, chunks, num_lines)
+        yield from generate_parallel(settings, _line_count, num_workers, chunk_size=5)

--- a/src/gretel_synthetics/generate_parallel.py
+++ b/src/gretel_synthetics/generate_parallel.py
@@ -1,19 +1,13 @@
 import multiprocessing
 from dataclasses import dataclass, field
-from typing import Iterable, List, Optional, Union, Tuple
+from typing import Iterable, List, Optional, Union, Set, Tuple
 import queue
 import os
 import sys
-
-import cloudpickle
+import loky
+from concurrent import futures
 
 from gretel_synthetics.generator import Generator, Settings, deserialize_settings, gen_text
-
-
-mp = multiprocessing.get_context('spawn')  # fork does not work with tensorflow
-
-
-MAX_QUEUE_SIZE = 30000
 
 
 @dataclass
@@ -31,20 +25,10 @@ class _WorkerStatus:
     done: bool = False
     """Flag indicating whether the worker is complete."""
 
-    def serialize(self) -> bytes:
-        return cloudpickle.dumps(self)
 
-
-def _deserialize_status(serialized: bytes) -> _WorkerStatus:
-    obj = cloudpickle.loads(serialized)
-    if not isinstance(obj, _WorkerStatus):
-        raise TypeError("serialized object is of type {}, not _WorkerStatus".format(type(obj).__name__))
-    return obj
-
-
-def split_work(parallelism: Union[int, float], total_lines: int, chunk_size: int = 5) -> Tuple[int, List[int]]:
+def get_num_workers(parallelism: Union[int, float], total_lines: int, chunk_size: int = 5) -> int:
     """
-    Given a parallelism setting and a number of total lines, split the work across workers.
+    Given a parallelism setting and a number of total lines, compute the number of parallel workers to be used.
 
     Args:
         parallelism: The number of concurrent workers to use. ``1`` (the default) disables parallelization,
@@ -55,7 +39,7 @@ def split_work(parallelism: Union[int, float], total_lines: int, chunk_size: int
         chunk_size: the size of an individual unit of work to be distributed to workers.
 
     Returns:
-        A pair consisting of the number of required workers, and the list of chunks of work.
+        The number of required workers.
     """
     num_chunks = (total_lines - 1) // chunk_size + 1
     non_positive = False
@@ -64,25 +48,19 @@ def split_work(parallelism: Union[int, float], total_lines: int, chunk_size: int
         non_positive = True
 
     if isinstance(parallelism, float):
-        num_workers = int(mp.cpu_count() * parallelism)
+        num_workers = int(loky.cpu_count() * parallelism)
     else:
         num_workers = parallelism
 
     if non_positive:
-        num_workers = mp.cpu_count() - num_workers
+        num_workers = loky.cpu_count() - num_workers
 
     num_workers = min(max(num_workers, 1), num_chunks)
 
-    if num_workers == 1:
-        return 1, [total_lines]
-
-    chunks = [chunk_size] * (num_chunks - 1)
-    chunks.append(total_lines - sum(chunks))
-
-    return num_workers, chunks
+    return num_workers
 
 
-def generate_parallel(settings: Settings, num_workers: int, chunks: List[int], num_lines: int):
+def generate_parallel(settings: Settings, num_lines: int, num_workers: int, chunk_size: int = 5):
     """
     Runs text generation in parallel mode.
 
@@ -91,108 +69,92 @@ def generate_parallel(settings: Settings, num_workers: int, chunks: List[int], n
 
     Args:
         settings: the settings for text generation.
+        num_lines: the number of valid lines to be generated.
         num_workers: the number of parallel workers.
-        chunks: the list of chunks of work.
+        chunk_size: the maximum number of lines to be assigned to a worker at once.
 
     Yields:
         ``gen_text`` objects.
     """
 
-    # Instruct each worker to return an intermediate result (at the cost of putting a partial chunk
-    # back into the queue) if it has generated 105% of the requested number of valid lines per chunk
-    # (regardless of how many lines are valid in the intermediate result). This ensures that workers
-    # don't get stuck for a long time generating data from bad models, where the ratio of invalid:valid
-    # lines is very high.
-    max_response_size = int(chunks[0] * 1.05)
+    # Create a pool of workers that will instantiate a generator upon initialization.
+    worker_pool = loky.ProcessPoolExecutor(
+        max_workers=num_workers,
+        initializer=_loky_init_worker,
+        initargs=(settings,)
+    )
 
-    worker_input_queue = mp.Queue(MAX_QUEUE_SIZE)
+    # How many valid lines we still need to generate
+    remaining_lines = num_lines
 
-    # Because of the upper limit on the max queue size, we pre-load
-    # either all chunks or the max queue size amount of chunks
-    # If there are still more chunks, we'll load those into the queue
-    # as space becomes more available
-    for _ in range(min(MAX_QUEUE_SIZE, len(chunks))):
-        chunk = chunks.pop()
-        worker_input_queue.put_nowait(chunk)
+    # This set tracks the currently outstanding invocations to _loky_worker_process_chunk.
+    pending_tasks: Set[futures.Future[Tuple[int, List[gen_text], int]]] = set()
 
-    # Create a queue for output produced by the worker. This queue should be large enough to buffer all
-    # intermediate statuses to ensure that upstream processing doesn't block downstream workers.
-    worker_output_queue = mp.Queue(MAX_QUEUE_SIZE)
+    # How many tasks can be pending at once. While a lower factor saves memory, it increases the
+    # risk that workers sit idle because the main process is blocked on processing data and
+    # therefore cannot hand out new tasks.
+    max_pending_tasks = 10 * num_workers
 
-    pickled_settings = cloudpickle.dumps(settings)
+    # How many lines to be generated have been assigned to currently active workers. This tracks
+    # the nominal/target lines, and the returned number of lines may be different if workers generate
+    # a lot of invalid lines.
+    assigned_lines = 0
 
-    workers = [
-        mp.Process(
-            target=_run_parallel_worker,
-            args=(pickled_settings, worker_input_queue, worker_output_queue, max_response_size),
-        )
-        for _ in range(num_workers)
-    ]
-
-    # Start all the worker processes.
-    for worker in workers:
-        worker.start()
-
-    live_workers = len(workers)
+    # The _total_ number of invalid lines we have seen so far. This is used to implement a global
+    # limit on the number of invalid lines, since each worker only knows the number of invalid lines
+    # it has generated itself.
     total_invalid = 0
-    total_valid = 0
-    while live_workers > 0:
-        output = worker_output_queue.get()
 
-        # A worker should always send a pickled WorkerStatus after completing each chunk or the entire job.
-        # However, we also allow sending a raw string as an escape hatch to communicate, e.g., exceptions while
-        # serializing.
-        if isinstance(output, str):
-            raise RuntimeError('Fatal top-level exception from worker: {}'.format(output))
+    try:
+        while remaining_lines > 0:
+            # If we have capacity to add new pending tasks, do so until we are at capacity or there are
+            # no more lines that can be assigned to workers.
+            while len(pending_tasks) < max_pending_tasks and assigned_lines < remaining_lines:
+                next_chunk = min(chunk_size, remaining_lines)
+                pending_tasks.add(worker_pool.submit(_loky_worker_process_chunk, next_chunk))
+                assigned_lines += next_chunk
 
-        parsed_output = _deserialize_status(output)
+            # Wait for at least one worker to complete its current task (or fail with an exception).
+            completed_tasks, pending_tasks = futures.wait(
+                pending_tasks, return_when=futures.FIRST_COMPLETED)
 
-        if parsed_output.exception is not None:
-            # First order of business: check for any exception and raise in the main program.
-            raise parsed_output.exception
+            for task in completed_tasks:
+                requested_chunk_size, lines, num_invalid = task.result(timeout=0)
 
-        # Emit lines in the output
-        for line in parsed_output.lines:
-            if line.valid is not None and not line.valid:
-                total_invalid += 1
-            else:
-                total_valid += 1
-            if total_invalid > settings.max_invalid:
-                raise RuntimeError("Maximum number of invalid lines reached!")
-            yield line
+                assigned_lines -= requested_chunk_size
+                remaining_lines -= len(lines) - num_invalid  # Calculate number of _valid_ lines
 
-        if parsed_output.done:
-            live_workers -= 1  # We aren't expecting anything more from this worker
+                # Emit lines in the output
+                for line in lines:
+                    if line.valid is not None and not line.valid:
+                        total_invalid += 1
+                    if total_invalid > settings.max_invalid:
+                        raise RuntimeError("Maximum number of invalid lines reached!")
+                    yield line
 
-        # if there are still chunks left, try and add them to the queue
-        # if there are no more chunks, signal the workers to shutdown
-        while True:
-            if not chunks:
-                break
-            chunk = chunks.pop()
-            try:
-                worker_input_queue.put_nowait(chunk)
-            except queue.Full:
-                chunks.append(chunk)
-                break
-
-        if total_valid == num_lines:
-            for _ in range(len(workers)):
-                try:
-                    worker_input_queue.put_nowait(None)
-                except queue.Full:
-                    pass
-
-    # Join all worker processes (not strictly necessary, but cleaner).
-    for worker in workers:
-        worker.join()
+    finally:
+        # Always make sure to shut down the worker pool (no need to wait for workers to terminate).
+        worker_pool.shutdown(wait=False, kill_workers=True)
 
 
-def _run_parallel_worker(
-        pickled_settings: bytes,
-        input_queue: mp.Queue,
-        output_queue: mp.Queue,
-        max_response_size: Optional[int] = None):
+###################################################################
+# All code below this line is ONLY run in workers spawned by loky #
+###################################################################
+
+
+# Global variable for the generator used in this process. Since we are not reusing processes across
+# generation tasks, we do not lose any ability of running multiple top-level generation tasks in parallel.
+# Also note that each worker picks up tasks in a strictly sequential fashion and is not multi-threaded.
+_loky_worker_generator : Optional[Generator] = None
+
+
+def _loky_init_worker(settings: Settings):
+    """
+    Initializes the global state for a loky worker process.
+
+    Args:
+        settings: the settings for the generator.
+    """
     # Workers should be using CPU only (note, this has no effect on the parent process)
     os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
 
@@ -204,47 +166,33 @@ def _run_parallel_worker(
     except BaseException:  # pylint: disable=broad-except
         pass
 
-    try:
-        settings = deserialize_settings(pickled_settings)
-
-        for status in _process_all_chunks(settings, input_queue, max_response_size):
-            output_queue.put(cloudpickle.dumps(status))
-    except BaseException as e:
-        # Catch serialization errors etc., and put into queue as a raw str to avoid triggering an exception a
-        # second time that was caused by lack of serializability.
-        output_queue.put(str(e))
+    global _loky_worker_generator
+    _loky_worker_generator = Generator(settings)
 
 
-def _process_all_chunks(settings: Settings,
-                        input_queue: mp.Queue,
-                        max_response_size: Optional[int] = None) -> Iterable[_WorkerStatus]:
-    try:
-        gen = Generator(settings)
+def _loky_worker_process_chunk(chunk_size: int) -> Tuple[int, List[gen_text], int]:
+    """
+    Processes a single chunk by attempting to generate the given number of lines.
 
-        while True:
-            chunk_size = input_queue.get()
-            if chunk_size is None:
-                yield _WorkerStatus(done=True)
-                break
-            prev_invalid = gen.total_invalid
-            all_lines = list(gen.generate_next(chunk_size, hard_limit=max_response_size))
-            num_valid_lines = len(all_lines) - (gen.total_invalid - prev_invalid)
-            if num_valid_lines < chunk_size:
-                # Return the number of lines by which we fell short to the queue.
-                # This is guaranteed to succeed because every worker will only do this after
-                # at least removing an element from the queue, thus ensuring that capacity
-                # constraints are never violated.
-                input_queue.put(chunk_size - num_valid_lines)
-            yield _WorkerStatus(lines=all_lines)
-    except queue.Empty:
-        # NOTE: We shouldn't really get here, but leaving it for now, since we are
-        # relying on signaling shutdown via a sentinel
-        #
-        # It is possible that further elements will be added to the queue
-        # because a worker generated too many invalid lines, but in this case we can be certain
-        # that the number of running workers will never fall below the number of concurrently
-        # pending chunks.
-        yield _WorkerStatus(done=True)
-    except BaseException as e:
-        # Send any exception in its own status object.
-        yield _WorkerStatus(exception=e, done=True)
+    Args:
+        chunk_size: the desired (target) number of valid lines to generate.
+
+    Returns:
+        3-element tuple containing:
+        - the original input value of ``chunk_size``,
+        - the list of all generated lines (valid and invalid), and
+        - the number of invalid lines among the generated ones.
+
+    Raises:
+        RuntimeError: if _loky_init_worker has not been called yet in this process.
+    """
+
+    global _loky_worker_generator
+    if not _loky_worker_generator:
+        raise RuntimeError("generator has not been initialized in loky worker process")
+
+    old_num_invalid = _loky_worker_generator.total_invalid
+    lines = list(_loky_worker_generator.generate_next(chunk_size))
+    num_invalid = _loky_worker_generator.total_invalid - old_num_invalid
+
+    return chunk_size, lines, num_invalid

--- a/src/gretel_synthetics/generate_parallel.py
+++ b/src/gretel_synthetics/generate_parallel.py
@@ -143,7 +143,7 @@ def generate_parallel(settings: Settings, num_lines: int, num_workers: int, chun
 # Global variable for the generator used in this process. Since we are not reusing processes across
 # generation tasks, we do not lose any ability of running multiple top-level generation tasks in parallel.
 # Also note that each worker picks up tasks in a strictly sequential fashion and is not multi-threaded.
-_loky_worker_generator : Optional[Generator] = None
+_loky_worker_generator: Optional[Generator] = None
 
 
 def _loky_init_worker(settings: Settings):

--- a/src/gretel_synthetics/generate_parallel.py
+++ b/src/gretel_synthetics/generate_parallel.py
@@ -1,13 +1,11 @@
-import multiprocessing
 from dataclasses import dataclass, field
-from typing import Iterable, List, Optional, Union, Set, Tuple
-import queue
+from typing import List, Optional, Union, Set, Tuple
 import os
 import sys
 import loky
 from concurrent import futures
 
-from gretel_synthetics.generator import Generator, Settings, deserialize_settings, gen_text
+from gretel_synthetics.generator import Generator, Settings, gen_text
 
 
 @dataclass

--- a/src/gretel_synthetics/generator.py
+++ b/src/gretel_synthetics/generator.py
@@ -104,6 +104,10 @@ class gen_text:
         return None
 
 
+class TooManyInvalidError(RuntimeError):
+    pass
+
+
 class Generator:
     """
     A class for generating synthetic lines of text.
@@ -172,7 +176,7 @@ class Generator:
                     ...
 
             if self.total_invalid > self.settings.max_invalid:
-                raise RuntimeError("Maximum number of invalid lines reached!")
+                raise TooManyInvalidError("Maximum number of invalid lines reached!")
 
 
 def _predict_chars(

--- a/src/gretel_synthetics/generator.py
+++ b/src/gretel_synthetics/generator.py
@@ -2,8 +2,6 @@ from typing import TYPE_CHECKING, Callable, List, Iterable, Optional, Tuple
 from dataclasses import dataclass, asdict
 from collections import namedtuple
 
-import cloudpickle
-
 import sentencepiece as spm
 import tensorflow as tf
 
@@ -63,28 +61,6 @@ class Settings:
     start_string: str = "<n>"
     line_validator: Optional[Callable] = None
     max_invalid: int = 1000
-
-    def serialize(self) -> bytes:
-        return cloudpickle.dumps(self)
-
-
-def deserialize_settings(serialized: bytes) -> Settings:
-    """
-    Deserializes a serialized ``Settings`` instance.
-
-    Args:
-        serialized: the bytes of the serialized ``Settings`` instance.
-
-    Returns:
-        The deserialized ``Settings`` instance.
-
-    Raises:
-        A ``TypeError`` if the deserialized object is not a ``Settings`` instance.
-    """
-    obj = cloudpickle.loads(serialized)
-    if not isinstance(obj, Settings):
-        raise TypeError("deserialized object is of type {}, not Settings".format(type(obj).__name__))
-    return obj
 
 
 @dataclass

--- a/tests/test_generate_parallel.py
+++ b/tests/test_generate_parallel.py
@@ -1,26 +1,23 @@
 from unittest.mock import patch
 import pytest
 
-from gretel_synthetics.generate_parallel import split_work
+from gretel_synthetics.generate_parallel import get_num_workers
 
 
-@pytest.mark.parametrize('num_cpus,total_lines,chunk_size,parallelism,expected_workers,expected_chunks',
-                         [(1, 100, 5, 0, 1, 1),
-                          (1, 100, 5, 1, 1, 1),
-                          (8, 100, 5, 0, 8, 20),
-                          (8, 100, 9, 0, 8, 12),
-                          (8, 100, 5, 1, 1, 1),
-                          (8, 100, 5, -1, 7, 20),
-                          (8, 100, 5, .5, 4, 20),
-                          (8, 100, 50, .5, 2, 2),
-                          (8, 100, 5, -.5, 4, 20),
+@pytest.mark.parametrize('num_cpus,total_lines,chunk_size,parallelism,expected_workers',
+                         [(1, 100, 5, 0, 1),
+                          (1, 100, 5, 1, 1),
+                          (8, 100, 5, 0, 8),
+                          (8, 100, 9, 0, 8),
+                          (8, 100, 5, 1, 1),
+                          (8, 100, 5, -1, 7),
+                          (8, 100, 5, .5, 4),
+                          (8, 100, 50, .5, 2),
+                          (8, 100, 5, -.5, 4),
                           ])
-@patch("gretel_synthetics.generate_parallel.mp.cpu_count")
-def test_split_work(cpu_count, num_cpus, total_lines, chunk_size, parallelism, expected_workers, expected_chunks):
+@patch("loky.cpu_count")
+def test_split_work(cpu_count, num_cpus, total_lines, chunk_size, parallelism, expected_workers):
     cpu_count.return_value = num_cpus
 
-    num_workers, chunks = split_work(parallelism, total_lines, chunk_size)
+    num_workers = get_num_workers(parallelism, total_lines, chunk_size)
     assert num_workers == expected_workers
-    assert len(chunks) == expected_chunks
-    assert all(x == chunk_size for x in chunks[:-1])
-    assert sum(chunks) == total_lines


### PR DESCRIPTION
loky generally works better with interpreters like `ipython` and for standalone scripts that do not use the `if __name__ == '__main__'` pattern. It also uses `cloudpickle` by default, so no need to use that at the application level.

The major rework is necessary because loky uses a different paradigm compared to multiprocessing: communication can only happen between the parent and the child processes by invoking a function in the child process; i.e., exchange of data is limited to the function call/return boundary. Instead of maintaining a queue of work items, tasks are submitted for execution to a pool-based executor. Instead of dividing the work into chunks ahead of time, we merely track the number of remaining valid lines that we want generated as a number, and make sure that the number of outstanding tasks is high enough to keep all the workers busy while the main process processes data returned from the worker.
An added benefit of this approach is that the division of work no longer suffers from fragmentation, as the current approach does.