### PR TITLE
Fix a mismatch in assigning task to workers

### DIFF
--- a/src/gretel_synthetics/batch.py
+++ b/src/gretel_synthetics/batch.py
@@ -441,7 +441,7 @@ class DataFrameBatch:
                 return False
         t.close()
         t2.close()
-        return batch.gen_data_count == num_lines
+        return batch.gen_data_count >= num_lines
 
     def generate_all_batch_lines(
         self, max_invalid=MAX_INVALID, raise_on_failed_batch: bool = False, num_lines: int = None,

--- a/src/gretel_synthetics/generate_parallel.py
+++ b/src/gretel_synthetics/generate_parallel.py
@@ -97,7 +97,7 @@ def generate_parallel(settings: Settings, num_lines: int, num_workers: int, chun
             # If we have capacity to add new pending tasks, do so until we are at capacity or there are
             # no more lines that can be assigned to workers.
             while len(pending_tasks) < max_pending_tasks and assigned_lines < remaining_lines:
-                next_chunk = min(chunk_size, remaining_lines)
+                next_chunk = min(chunk_size, remaining_lines - assigned_lines)
                 pending_tasks.add(worker_pool.submit(_loky_worker_process_chunk, next_chunk, hard_limit))
                 assigned_lines += next_chunk
 

--- a/tests/test_generate_parallel.py
+++ b/tests/test_generate_parallel.py
@@ -1,7 +1,11 @@
-from unittest.mock import patch
+from unittest.mock import patch, Mock
+from typing import Optional
+from concurrent import futures
+from math import ceil
 import pytest
 
-from gretel_synthetics.generate_parallel import get_num_workers
+from gretel_synthetics.generator import gen_text, TooManyInvalidError
+from gretel_synthetics.generate_parallel import generate_parallel, get_num_workers
 
 
 @pytest.mark.parametrize('num_cpus,total_lines,chunk_size,parallelism,expected_workers',
@@ -21,3 +25,57 @@ def test_split_work(cpu_count, num_cpus, total_lines, chunk_size, parallelism, e
 
     num_workers = get_num_workers(parallelism, total_lines, chunk_size)
     assert num_workers == expected_workers
+
+
+def _mock_submitter(failure_rate):
+    def mock_submit(unused_fn, chunk_size: int, hard_limit: Optional[int] = None):
+        target_valid = chunk_size
+        target_total = int((1 + failure_rate) * chunk_size)
+        if hard_limit is not None and target_total > hard_limit:
+            target_valid = ceil(chunk_size * (hard_limit / target_total))
+            target_total = hard_limit
+
+        target_invalid = target_total - target_valid
+
+        lines = [gen_text(text=f'line-{i}', valid=(i >= target_invalid)) for i in range(target_total)]
+        mock_future = futures.Future()
+        mock_future.set_result((chunk_size, lines, target_invalid))
+
+        return mock_future
+
+    return mock_submit
+
+
+@pytest.mark.parametrize('num_lines,num_workers,chunk_size,failure_rate',
+                         [(num_lines, num_workers, chunk_size, failure_rate)
+                          for num_lines in (10, 100, 1000)
+                          for num_workers in (1, 4, 8, 12, 13, 16)
+                          for chunk_size in (1, 5, 10, 50)
+                          for failure_rate in (0.0, 0.25, 0.5)])
+@patch("loky.ProcessPoolExecutor")
+def test_generate_parallel(pool_mock, num_lines, num_workers, chunk_size, failure_rate):
+    pool_instance = pool_mock.return_value
+    pool_instance.submit.side_effect = _mock_submitter(failure_rate)
+
+    settings_mock = Mock()
+    settings_mock.max_invalid = ceil(failure_rate * num_lines)
+
+    lines = list(generate_parallel(settings_mock, num_lines, num_workers, chunk_size))
+    valid_lines = sum(1 for line in lines if line.valid)
+    invalid_lines = sum(1 for line in lines if not line.valid)
+
+    assert valid_lines == num_lines
+    assert invalid_lines <= ceil(failure_rate * num_lines)
+
+
+@patch("loky.ProcessPoolExecutor")
+def test_generate_parallel_too_many_invalid(pool_mock):
+    pool_instance = pool_mock.return_value
+    pool_instance.submit.side_effect = _mock_submitter(0.5)  # 0.5 failure rate
+
+    settings_mock = Mock()
+    settings_mock.max_invalid = 250 # 0.25 failure rate budget
+
+    with pytest.raises(TooManyInvalidError):
+        for _ in generate_parallel(settings_mock, 1000, 2, 10):
+            pass


### PR DESCRIPTION
This fixes a bug where slightly more than the requested number of lines could be generated, because the chunk size handed out to a single worker was capped at the number of remaining (not yet generated) lines, not remaining - assigned.

This also adds a unit test for the parallel generation, with the actual parallel execution mocked out (it doesn't seem possible to have mock patches propagate to subprocesses), ensuring among other things that the number of generated lines matches precisely what was requested.

The change of the success condition in `batch.py` is purely defensive and should not be required with this change.