### PR TITLE
SYN-9 Display html report in notebook cell.

### DIFF
--- a/examples/launch_synthetics.ipynb
+++ b/examples/launch_synthetics.ipynb
@@ -248,7 +248,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bundle.generate_report()"
+    "from IPython.core.display import display\n",
+    "from IPython.display import IFrame\n",
+    "\n",
+    "# By default Distribution Comparison figures are only generated for categories with <= 60 unique values.\n",
+    "# Use the plot_max_unique_values parameter to generate_report to change this.\n",
+    "bundle.generate_report(report_path=\"./report.html\")\n",
+    "display(IFrame(\"./report.html\", 1000, 600))"
    ]
   }
  ],


### PR DESCRIPTION
Little change in the launch_synthetics notebook.  The bundle.generate_report call now writes html to './reports/' and we render it in the notebook cell.