### PR TITLE
Aw/SYN-39: Enable DP experimental mode **DRAFT**

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow==2.3.1
+tensorflow==2.4.0rc1
 tensorflow_privacy==0.5.1
 sentencepiece==0.1.91
 smart_open>=2.1.0,<3.0
@@ -6,4 +6,4 @@ pandas>=1.1.0
 numpy>=1.18.0
 tqdm<5.0
 loky==2.8.0
-gast==0.3.3
+gast==0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas>=1.1.0
 numpy>=1.18.0
 tqdm<5.0
 loky==2.8.0
+gast==0.3.3

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'numpy>=1.18.0',
         'dataclasses==0.7;python_version<"3.7"',
         'loky==2.8.0',
+        'gast==0.3.3'
     ],
     extras_require={
         'tf': ['tensorflow==2.3.1']

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,10 @@ setup(
         'numpy>=1.18.0',
         'dataclasses==0.7;python_version<"3.7"',
         'loky==2.8.0',
-        'gast==0.3.3'
+        'gast==0.4'
     ],
     extras_require={
-        'tf': ['tensorflow==2.3.1']
+        'tf': ['tensorflow==2.4.0rc1']
     },
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/src/gretel_synthetics/config.py
+++ b/src/gretel_synthetics/config.py
@@ -6,6 +6,7 @@ For example usage please see our Jupyter Notebooks.
 """
 import json
 import logging
+import tensorflow as tf
 from pathlib import Path
 from abc import abstractmethod
 from dataclasses import dataclass, asdict, field
@@ -232,14 +233,16 @@ class LocalConfig(BaseConfig, _PathSettingsMixin):
     input_data_path: str = None
 
     def __post_init__(self):
-        # FIXME: Remove @ 0.15.X when new optimizers are available for DP
         if self.dp:
-            raise RuntimeError(
-                "DP mode is disabled in v0.14.X. Please remove or set this value to ``False`` to continue with out DP.  DP will be re-enabled in v0.15.X. Please see the README for more details"  # noqa
-            )
+            major, minor, micro = tf.__version__.split(".")
+            if int(minor) < 4 and int(major) >= 2:
+                raise RuntimeError(
+                    "Running in differential privacy mode requires TensorFlow 2.4.x or greater. "
+                    "Please see the README for details"
+                )
 
         if self.best_model_metric not in (VAL_LOSS, VAL_ACC):
-            raise AttributeError("Invalid value for bset_model_metric")
+            raise AttributeError("Invalid value for best_model_metric")
         if not self.checkpoint_dir or not self.input_data_path:
             raise AttributeError(
                 "Must provide checkpoint_dir and input_path_dir params!"

--- a/src/gretel_synthetics/config.py
+++ b/src/gretel_synthetics/config.py
@@ -93,16 +93,17 @@ class BaseConfig:
             the protections offered for sensitive data and content, at a small loss in model
             accuracy and synthetic data quality. The differential privacy epsilon and delta values
             will be printed when training completes. Default is ``False``.
-        dp_learning_rate (optional): The higher the learning rate, the more that each update during
-            training matters. If the updates are noisy (such as when the additive noise is large
+        learning_rate (optional): The higher the learning rate, the more that each update during
+            training matters. Note: When training with differential privacy enabled,
+            if the updates are noisy (such as when the additive noise is large
             compared to the clipping threshold), a low learning rate may help with training.
-            Default is ``0.015``.
+            Default is ``0.001``.
         dp_noise_multiplier (optional): The amount of noise sampled and added to gradients during
             training. Generally, more noise results in better privacy, at the expense of
-            model accuracy. Default is ``1.1``.
+            model accuracy. Default is ``0.1``.
         dp_l2_norm_clip (optional): The maximum Euclidean (L2) norm of each gradient is applied to
             update model parameters. This hyperparameter bounds the optimizer's sensitivity to
-            individual training points. Default is ``1.0``.
+            individual training points. Default is ``3.0``.
         dp_microbatches (optional): Each batch of data is split into smaller units called micro-batches.
             Computational overhead can be reduced by increasing the size of micro-batches to include
             more than one training example. The number of micro-batches should divide evenly into
@@ -140,6 +141,7 @@ class BaseConfig:
     seq_length: int = 100
     embedding_dim: int = 256
     rnn_units: int = 256
+    learning_rate: float = 0.001
     dropout_rate: float = 0.2
     rnn_initializer: str = "glorot_uniform"
 
@@ -155,10 +157,9 @@ class BaseConfig:
 
     # Diff privacy configs
     dp: bool = False
-    dp_learning_rate: float = 0.001
-    dp_noise_multiplier: float = 1.1
-    dp_l2_norm_clip: float = 1.0
-    dp_microbatches: int = 256
+    dp_noise_multiplier: float = 0.1
+    dp_l2_norm_clip: float = 3.0
+    dp_microbatches: int = 64
 
     # Generation settings
     gen_temp: float = 1.0

--- a/src/gretel_synthetics/config.py
+++ b/src/gretel_synthetics/config.py
@@ -168,7 +168,7 @@ class BaseConfig:
     gen_chars: int = 0
     gen_lines: int = 1000
     predict_batch_size: int = 64
-    reset_states: True
+    reset_states: bool = True
 
     # Checkpoint storage
     save_all_checkpoints: bool = False

--- a/src/gretel_synthetics/config.py
+++ b/src/gretel_synthetics/config.py
@@ -117,6 +117,8 @@ class BaseConfig:
             by the model pass validation. Default is ``1000``.
         predict_batch_size (optional): How many words to generate in parallel. Higher values may result in increased
             throughput. The default of ``64`` should provide reasonable performance for most users.
+        reset_states (optional): Reset RNN model states between each record created guarantees more
+            consistent record creation over time, at the expense of model accuracy. Default is ``True``.
         save_all_checkpoints (optional). Set to ``True`` to save all model checkpoints as they are created,
             which can be useful for optimal model selection. Set to ``False`` to save only the latest
             checkpoint. Default is ``True``.
@@ -166,6 +168,7 @@ class BaseConfig:
     gen_chars: int = 0
     gen_lines: int = 1000
     predict_batch_size: int = 64
+    reset_states: True
 
     # Checkpoint storage
     save_all_checkpoints: bool = False

--- a/src/gretel_synthetics/default_model.py
+++ b/src/gretel_synthetics/default_model.py
@@ -1,8 +1,14 @@
 import logging
 import tensorflow as tf
 
+from tensorflow.keras.optimizers import RMSprop
 
-def build_default_model(optimizer_cls, store, batch_size, vocab_size) -> tf.keras.Sequential:
+
+def loss(labels, logits):
+    return tf.keras.losses.sparse_categorical_crossentropy(labels, logits, from_logits=True)
+
+
+def build_default_model(store, batch_size, vocab_size) -> tf.keras.Sequential:
     """
     Build a RNN-based sequential model
 
@@ -15,25 +21,27 @@ def build_default_model(optimizer_cls, store, batch_size, vocab_size) -> tf.kera
     Returns:
         tf.keras.Sequential model
     """
-    optimizer = optimizer_cls(
+    optimizer = RMSprop(
         learning_rate=store.learning_rate
     )
+
     model = tf.keras.Sequential([
         tf.keras.layers.Embedding(vocab_size, store.embedding_dim,
                                   batch_input_shape=[batch_size, None]),
         tf.keras.layers.Dropout(store.dropout_rate),
-        tf.keras.layers.GRU(store.rnn_units,
-                            return_sequences=True,
-                            stateful=True,
-                            recurrent_initializer=store.rnn_initializer),
+        tf.keras.layers.LSTM(store.rnn_units,
+                             return_sequences=True,
+                             stateful=True,
+                             recurrent_initializer=store.rnn_initializer),
         tf.keras.layers.Dropout(store.dropout_rate),
-        tf.keras.layers.GRU(store.rnn_units,
-                            return_sequences=True,
-                            stateful=True,
-                            recurrent_initializer=store.rnn_initializer),
+        tf.keras.layers.LSTM(store.rnn_units,
+                             return_sequences=True,
+                             stateful=True,
+                             recurrent_initializer=store.rnn_initializer),
         tf.keras.layers.Dropout(store.dropout_rate),
         tf.keras.layers.Dense(vocab_size)
     ])
 
     logging.info(f"Using {optimizer._keras_api_names[0]} optimizer")
+    model.compile(optimizer=optimizer, loss=loss, metrics=["accuracy"])
     return model

--- a/src/gretel_synthetics/default_model.py
+++ b/src/gretel_synthetics/default_model.py
@@ -1,0 +1,39 @@
+import logging
+import tensorflow as tf
+
+
+def build_default_model(optimizer_cls, store, batch_size, vocab_size) -> tf.keras.Sequential:
+    """
+    Build a RNN-based sequential model
+
+    Args:
+        optimizer_cls: tf.keras.optimizer class
+        store: LocalConfig
+        batch_size: Batch size for training and prediction
+        vocab_size: Size of training vocabulary
+
+    Returns:
+        tf.keras.Sequential model
+    """
+    optimizer = optimizer_cls(
+        learning_rate=store.learning_rate
+    )
+    model = tf.keras.Sequential([
+        tf.keras.layers.Embedding(vocab_size, store.embedding_dim,
+                                  batch_input_shape=[batch_size, None]),
+        tf.keras.layers.Dropout(store.dropout_rate),
+        tf.keras.layers.GRU(store.rnn_units,
+                            return_sequences=True,
+                            stateful=True,
+                            recurrent_initializer=store.rnn_initializer),
+        tf.keras.layers.Dropout(store.dropout_rate),
+        tf.keras.layers.GRU(store.rnn_units,
+                            return_sequences=True,
+                            stateful=True,
+                            recurrent_initializer=store.rnn_initializer),
+        tf.keras.layers.Dropout(store.dropout_rate),
+        tf.keras.layers.Dense(vocab_size)
+    ])
+
+    logging.info(f"Using {optimizer._keras_api_names[0]} optimizer")
+    return model

--- a/src/gretel_synthetics/default_model.py
+++ b/src/gretel_synthetics/default_model.py
@@ -13,7 +13,6 @@ def build_default_model(store, batch_size, vocab_size) -> tf.keras.Sequential:
     Build a RNN-based sequential model
 
     Args:
-        optimizer_cls: tf.keras.optimizer class
         store: LocalConfig
         batch_size: Batch size for training and prediction
         vocab_size: Size of training vocabulary

--- a/src/gretel_synthetics/dp_model.py
+++ b/src/gretel_synthetics/dp_model.py
@@ -32,14 +32,17 @@ def build_dp_model(store, batch_size, vocab_size) -> tf.keras.Sequential:
     model = tf.keras.Sequential([
         tf.keras.layers.Embedding(vocab_size, store.embedding_dim,
                                   batch_input_shape=[batch_size, None]),
-        tf.keras.layers.GRU(store.rnn_units,
-                            return_sequences=True,
-                            stateful=True,
-                            recurrent_initializer=store.rnn_initializer),
-        tf.keras.layers.GRU(store.rnn_units,
-                            return_sequences=True,
-                            stateful=True,
-                            recurrent_initializer=store.rnn_initializer),
+        tf.keras.layers.Dropout(store.dropout_rate),
+        tf.keras.layers.LSTM(store.rnn_units,
+                             return_sequences=True,
+                             stateful=True,
+                             recurrent_initializer=store.rnn_initializer),
+        tf.keras.layers.Dropout(store.dropout_rate),
+        tf.keras.layers.LSTM(store.rnn_units,
+                             return_sequences=True,
+                             stateful=True,
+                             recurrent_initializer=store.rnn_initializer),
+        tf.keras.layers.Dropout(store.dropout_rate),
         tf.keras.layers.Dense(vocab_size)
     ])
 

--- a/src/gretel_synthetics/dp_model.py
+++ b/src/gretel_synthetics/dp_model.py
@@ -25,17 +25,14 @@ def build_dp_model(optimizer_cls, store, batch_size, vocab_size) -> tf.keras.Seq
     model = tf.keras.Sequential([
         tf.keras.layers.Embedding(vocab_size, store.embedding_dim,
                                   batch_input_shape=[batch_size, None]),
-        tf.keras.layers.Dropout(store.dropout_rate),
         tf.keras.layers.GRU(store.rnn_units,
                             return_sequences=True,
                             stateful=True,
                             recurrent_initializer=store.rnn_initializer),
-        tf.keras.layers.Dropout(store.dropout_rate),
         tf.keras.layers.GRU(store.rnn_units,
                             return_sequences=True,
                             stateful=True,
                             recurrent_initializer=store.rnn_initializer),
-        tf.keras.layers.Dropout(store.dropout_rate),
         tf.keras.layers.Dense(vocab_size)
     ])
 

--- a/src/gretel_synthetics/dp_model.py
+++ b/src/gretel_synthetics/dp_model.py
@@ -1,0 +1,43 @@
+import logging
+import tensorflow as tf
+
+
+def build_dp_model(optimizer_cls, store, batch_size, vocab_size) -> tf.keras.Sequential:
+    """
+    Build a RNN-based sequential model with differentially private training (Experimental)
+
+    Args:
+        optimizer_cls: Differentially private optimizer class
+        store: LocalConfig
+        batch_size: Batch size for training and prediction
+        vocab_size: Size of training vocabulary
+
+    Returns:
+        tf.keras.Sequential model
+    """
+    logging.warning("Experimental: Differentially private training enabled")
+    optimizer = optimizer_cls(
+        l2_norm_clip=store.dp_l2_norm_clip,
+        noise_multiplier=store.dp_noise_multiplier,
+        num_microbatches=store.dp_microbatches,
+        learning_rate=store.learning_rate
+    )
+    model = tf.keras.Sequential([
+        tf.keras.layers.Embedding(vocab_size, store.embedding_dim,
+                                  batch_input_shape=[batch_size, None]),
+        tf.keras.layers.Dropout(store.dropout_rate),
+        tf.keras.layers.GRU(store.rnn_units,
+                            return_sequences=True,
+                            stateful=True,
+                            recurrent_initializer=store.rnn_initializer),
+        tf.keras.layers.Dropout(store.dropout_rate),
+        tf.keras.layers.GRU(store.rnn_units,
+                            return_sequences=True,
+                            stateful=True,
+                            recurrent_initializer=store.rnn_initializer),
+        tf.keras.layers.Dropout(store.dropout_rate),
+        tf.keras.layers.Dense(vocab_size)
+    ])
+
+    logging.info(f"Using {optimizer._keras_api_names[0]} optimizer in differentially private mode")
+    return model

--- a/src/gretel_synthetics/generate.py
+++ b/src/gretel_synthetics/generate.py
@@ -43,7 +43,7 @@ def generate_text(
             By default we use a newline, but you may substitue any initial value here
             which will influence how the generator predicts what to generate. If you
             are working with a field delimiter, and you want to seed more than one column
-            value, then you MUST utilize the field delimiter specified in your config. 
+            value, then you MUST utilize the field delimiter specified in your config.
             An example would be "foo,bar,baz,". Also, if using a field delimiter, the string
             MUST end with the delimiter value.
         line_validator: An optional callback validator function that will take
@@ -95,6 +95,12 @@ def generate_text(
     logging.info(
         f"Latest checkpoint: {tf.train.latest_checkpoint(config.checkpoint_dir)}"
     )  # noqa
+
+    if config.dp:
+        # Disable batching in DP mode when generating text
+        # as it reduces prediction accuracy
+        config.batch_size = 1
+        config.predict_batch_size = 1
 
     settings = Settings(
         config=config,

--- a/src/gretel_synthetics/generate.py
+++ b/src/gretel_synthetics/generate.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Callable
 import tensorflow as tf
 
 from gretel_synthetics.generator import Generator, Settings, NEWLINE
-from gretel_synthetics.generator import gen_text, PredString  # noqa # pylint: disable=unused-import
 from gretel_synthetics.generate_parallel import get_num_workers, generate_parallel
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -94,13 +93,14 @@ def generate_text(
     """
     logging.info(
         f"Latest checkpoint: {tf.train.latest_checkpoint(config.checkpoint_dir)}"
-    )  # noqa
+    )
 
-    if config.dp:
-        # Disable batching in DP mode when generating text
-        # as it reduces prediction accuracy
-        config.batch_size = 1
+    # Disable batching in DP mode when generating text
+    # as it reduces prediction accuracy (but faster)
+    if config.dp and (config.predict_batch_size > 1 or config.batch_size > 1):
+        logging.warning("Batch predictions not supported in DP mode.")
         config.predict_batch_size = 1
+        config.batch_size = 1
 
     settings = Settings(
         config=config,

--- a/src/gretel_synthetics/generate.py
+++ b/src/gretel_synthetics/generate.py
@@ -95,13 +95,6 @@ def generate_text(
         f"Latest checkpoint: {tf.train.latest_checkpoint(config.checkpoint_dir)}"
     )
 
-    # Disable batching in DP mode when generating text
-    # as it reduces prediction accuracy (but faster)
-    if config.dp and (config.predict_batch_size > 1 or config.batch_size > 1):
-        logging.warning("Batch predictions not supported in DP mode.")
-        config.predict_batch_size = 1
-        config.batch_size = 1
-
     settings = Settings(
         config=config,
         start_string=start_string,

--- a/src/gretel_synthetics/generator.py
+++ b/src/gretel_synthetics/generator.py
@@ -278,7 +278,7 @@ def _predict_chars(
     batch_sentence_ids = [[] for _ in range(store.predict_batch_size)]
     not_done = set(i for i in range(store.predict_batch_size))
 
-    if store.reset_states():
+    if store.reset_states:
         # Reset RNN model states between each record created
         # guarantees more consistent record creation over time, at the
         # expense of model accuracy

--- a/src/gretel_synthetics/generator.py
+++ b/src/gretel_synthetics/generator.py
@@ -278,7 +278,8 @@ def _predict_chars(
     batch_sentence_ids = [[] for _ in range(store.predict_batch_size)]
     not_done = set(i for i in range(store.predict_batch_size))
 
-    model.reset_states()
+    if store.predict_batch_size > 1:
+        model.reset_states()
 
     # if the start string is not the default newline, then we create a prefix string
     # that we will append to each decoded prediction

--- a/src/gretel_synthetics/generator.py
+++ b/src/gretel_synthetics/generator.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 import sentencepiece as spm
 import tensorflow as tf
 
-from gretel_synthetics.model import build_sequential_model
+from gretel_synthetics.model import build_model
 
 if TYPE_CHECKING:
     from gretel_synthetics.config import BaseConfig, LocalConfig
@@ -29,7 +29,7 @@ def _load_tokenizer(store: LocalConfig) -> spm.SentencePieceProcessor:
 def _prepare_model(
     sp: spm.SentencePieceProcessor, batch_size: int, store: LocalConfig
 ) -> tf.keras.Sequential:  # pragma: no cover
-    model = build_sequential_model(
+    model = build_model(
         vocab_size=len(sp), batch_size=batch_size, store=store
     )
 

--- a/src/gretel_synthetics/generator.py
+++ b/src/gretel_synthetics/generator.py
@@ -278,7 +278,7 @@ def _predict_chars(
     batch_sentence_ids = [[] for _ in range(store.predict_batch_size)]
     not_done = set(i for i in range(store.predict_batch_size))
 
-    if not store.dp:
+    if store.reset_states():
         # Reset RNN model states between each record created
         # guarantees more consistent record creation over time, at the
         # expense of model accuracy

--- a/src/gretel_synthetics/generator.py
+++ b/src/gretel_synthetics/generator.py
@@ -278,7 +278,10 @@ def _predict_chars(
     batch_sentence_ids = [[] for _ in range(store.predict_batch_size)]
     not_done = set(i for i in range(store.predict_batch_size))
 
-    if store.predict_batch_size > 1:
+    if not store.dp:
+        # Reset RNN model states between each record created
+        # guarantees more consistent record creation over time, at the
+        # expense of model accuracy
         model.reset_states()
 
     # if the start string is not the default newline, then we create a prefix string

--- a/src/gretel_synthetics/model.py
+++ b/src/gretel_synthetics/model.py
@@ -48,11 +48,11 @@ def build_sequential_model(
             l2_norm_clip=store.dp_l2_norm_clip,
             noise_multiplier=store.dp_noise_multiplier,
             num_microbatches=store.dp_microbatches,
-            learning_rate=store.dp_learning_rate
+            learning_rate=store.learning_rate
         )
     else:
         logging.info("Differentially private training _not_ enabled")
-        optimizer = optimizer_cls(learning_rate=store.dp_learning_rate)
+        optimizer = optimizer_cls(learning_rate=store.learning_rate)
 
     model = tf.keras.Sequential([
         tf.keras.layers.Embedding(vocab_size, store.embedding_dim,

--- a/src/gretel_synthetics/model.py
+++ b/src/gretel_synthetics/model.py
@@ -2,10 +2,7 @@
 Tensorflow - Keras Sequential RNN (GRU)
 """
 from typing import Tuple, TYPE_CHECKING
-
 import tensorflow as tf
-from tensorflow.keras.optimizers import RMSprop  # pylint: disable=import-error
-from tensorflow_privacy.privacy.optimizers.dp_optimizer_keras import make_keras_optimizer_class
 from tensorflow_privacy.privacy.analysis import compute_dp_sgd_privacy
 
 from gretel_synthetics.default_model import build_default_model
@@ -16,34 +13,17 @@ if TYPE_CHECKING:
 else:
     BaseConfig = None
 
-DEFAULT = "default"
-OPTIMIZERS = {
-    DEFAULT: {'dp': make_keras_optimizer_class(RMSprop), 'default': RMSprop}
-}
-
-
-def select_optimizer(store: BaseConfig):
-    if store.dp:
-        return OPTIMIZERS[DEFAULT]["dp"]
-    else:
-        return OPTIMIZERS[DEFAULT][DEFAULT]
-
-
-def loss(labels, logits):
-    return tf.keras.losses.sparse_categorical_crossentropy(labels, logits, from_logits=True)
-
 
 def build_model(vocab_size: int, batch_size: int, store: BaseConfig) -> tf.keras.Sequential:
     """
     Utilizing tf.keras.Sequential model
     """
-    optimizer_cls = select_optimizer(store)
     model = None
 
     if store.dp:
-        model = build_dp_model(optimizer_cls, store, batch_size, vocab_size)
+        model = build_dp_model(store, batch_size, vocab_size)
     else:
-        model = build_default_model(optimizer_cls, store, batch_size, vocab_size)
+        model = build_default_model(store, batch_size, vocab_size)
 
     print(model.summary())
     return model

--- a/src/gretel_synthetics/model.py
+++ b/src/gretel_synthetics/model.py
@@ -16,8 +16,6 @@ else:
 
 
 DEFAULT = "default"
-
-
 OPTIMIZERS = {
     DEFAULT: {'dp': make_keras_optimizer_class(RMSprop), 'default': RMSprop}
 }

--- a/src/gretel_synthetics/train.py
+++ b/src/gretel_synthetics/train.py
@@ -74,18 +74,16 @@ def _save_history_csv(
     """
     Save model training history to CSV format
     """
-    perplexity = [2 ** x for x in history.losses]
     df = pd.DataFrame(
         zip(
             range(len(history.losses)),
             history.losses,
             history.accuracy,
-            perplexity,
             history.epsilons,
             history.deltas,
             history.best,
         ),
-        columns=["epoch", VAL_LOSS, VAL_ACC, "perplexity", "epsilon", "delta", "best"],
+        columns=["epoch", VAL_LOSS, VAL_ACC, "epsilon", "delta", "best"],
     )
 
     if not dp:

--- a/src/gretel_synthetics/train.py
+++ b/src/gretel_synthetics/train.py
@@ -18,7 +18,7 @@ from smart_open import open
 import tensorflow as tf
 from tqdm import tqdm
 
-from gretel_synthetics.model import build_sequential_model, compute_epsilon
+from gretel_synthetics.model import build_model, compute_epsilon
 from gretel_synthetics.config import BaseConfig, VAL_ACC, VAL_LOSS
 from gretel_synthetics.generator import _load_model, NEWLINE
 
@@ -150,7 +150,7 @@ def train_rnn(store: BaseConfig):
     sp = _train_tokenizer(store)
     total_token_count, dataset = _create_dataset(store, text, sp)
     logging.info("Initializing synthetic model")
-    model = build_sequential_model(
+    model = build_model(
         vocab_size=len(sp), batch_size=store.batch_size, store=store
     )
 


### PR DESCRIPTION
Opening draft PR for comments.

Goal: Re-introduce support for DP as experimental and non-DP modes for 0.15.x release.

- [x] 1x non-DP optimizer and RNN model
- [x] 1x DP optimizer and RNN model
- [x] DP flag controls which optimizer is used
- [x] remove dp_learning_rate config param
- [x] add learning_rate config param – applies to either DP or non

For the DP optimizer
- [ ] Subclass the TFP optimizer into our own local class, and overload the compute_gradients routine, all we should do here is throw an exception if the compute_gradients is NOT called
- [x] If DP is enabled, we need to assert that TF 2.4.x is installed and being used

- [ ] Provide sample datasets and configs for DP / non-DP mode