### PR TITLE
Specify requirements, update PyPi metadata

### DIFF
--- a/examples/tensorflow/diff_privacy.ipynb
+++ b/examples/tensorflow/diff_privacy.ipynb
@@ -20,6 +20,11 @@
         "id": "TY5zsaXme67e"
       },
       "source": [
+        "# Train a synthetic data model with differential privacy guarantees\n",
+        "\n",
+        "#!pip install -Uqq \"gretel-synthetics>=0.15.0\"\n",
+        "#!pip install -Uqq \"tensorflow==2.4.0rc1\"\n",
+        "\n",
         "from pathlib import Path\n",
         "\n",
         "from gretel_synthetics.config import TensorFlowConfig\n",

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     setup_requires=["setuptools_scm"],
     description='Synthetic Data Generation with optional Differential Privacy',
     url='https://github.com/gretelai/gretel-synthetics',
+    license='Apache-2.0',
     long_description=long_description,
     long_description_content_type='text/markdown',
     package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     setup_requires=["setuptools_scm"],
     description='Synthetic Data Generation with optional Differential Privacy',
     url='https://github.com/gretelai/gretel-synthetics',
-    license='Apache-2.0',
+    license='http://www.apache.org/licenses/LICENSE-2.0',
     long_description=long_description,
     long_description_content_type='text/markdown',
     package_dir={'': 'src'},


### PR DESCRIPTION
1. When running in differential privacy mode, require TF>=2.4.0rc1 (release candidate must be specified)
2. Update PyPi metadata to show license correctly.

Currently:
```
% pip show gretel-synthetics
Name: gretel-synthetics
Version: 0.15.0
Summary: Synthetic Data Generation with optional Differential Privacy
Home-page: https://github.com/gretelai/gretel-synthetics
Author: Gretel Labs, Inc.
Author-email: open-source@gretel.ai
License: UNKNOWN
Location: ~/opt/anaconda3/lib/python3.8/site-packages
Requires: tensorflow-privacy, pandas, loky, sentencepiece, gast, smart-open, tqdm, numpy
Required-by:
```