### PR TITLE
Add min_delta parameter to EarlyStopping callback

### DIFF
--- a/src/gretel_synthetics/config.py
+++ b/src/gretel_synthetics/config.py
@@ -235,6 +235,7 @@ class TensorFlowConfig(BaseConfig):
     epochs: int = 100
     early_stopping: bool = True
     early_stopping_patience: int = 5
+    early_stopping_min_delta: float = 0.001
     best_model_metric: str = None
     batch_size: int = 64
     buffer_size: int = 10000

--- a/src/gretel_synthetics/config.py
+++ b/src/gretel_synthetics/config.py
@@ -172,6 +172,8 @@ class TensorFlowConfig(BaseConfig):
         best_model_metric (optional). Defaults to "val_loss" or "loss" if a validation set is not used.
             The metric to use to track when a model is no longer improving. Alternative options are "val_acc"
             or "acc". A error will be raised if a valid value is not specified.
+        early_stopping_min_delta (optional). Defaults to 0.001.  Minimum change in ``best_model_metric`` to qualify 
+            as an improvement, i.e. an absolute change of less than min_delta will count as no improvement.
         batch_size (optional): Number of samples per gradient update. Using larger batch sizes can help
             make more efficient use of CPU/GPU parallelization, at the cost of memory.
             If unspecified, batch_size will default to ``64``.
@@ -235,8 +237,8 @@ class TensorFlowConfig(BaseConfig):
     epochs: int = 100
     early_stopping: bool = True
     early_stopping_patience: int = 5
-    early_stopping_min_delta: float = 0.001
     best_model_metric: str = None
+    early_stopping_min_delta: float = 0.001
     batch_size: int = 64
     buffer_size: int = 10000
     seq_length: int = 100

--- a/src/gretel_synthetics/tensorflow/train.py
+++ b/src/gretel_synthetics/tensorflow/train.py
@@ -229,6 +229,7 @@ def train_rnn(params: TrainingParams):
         early_stopping_callback = tf.keras.callbacks.EarlyStopping(
             monitor=store.best_model_metric,
             patience=store.early_stopping_patience,
+            min_delta=store.early_stopping_min_delta,
             restore_best_weights=store.save_best_model,
         )
         _callbacks.append(early_stopping_callback)

--- a/tests/tensorflow/test_tf_config.py
+++ b/tests/tensorflow/test_tf_config.py
@@ -32,6 +32,7 @@ def test_local_config_settings(mkdir):
         "epochs": 100,
         "epoch_callback": None,
         "early_stopping": True,
+        'early_stopping_min_delta': 0.001,
         "early_stopping_patience": 5,
         "validation_split": True,
         "best_model_metric": METRIC_VAL_LOSS,


### PR DESCRIPTION
Adds the `min_delta` tf config parameter to enable better early stopping and a corresponding update to config tests.