### PR TITLE
Update requirement setup

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,12 +17,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.6
-    - name: Install TF 
+    - name: Install TF
       run:  pip install tensorflow==2.4
     - name: Install gretel-synthetics
-      run: pip install -e .
-    - name: Install Test Requirements
-      run: pip install -r test-requirements.txt
+      run: pip install -e .[all,test]
     - name: Test
       run: pytest -s -vv --cov src --cov-report term-missing tests-integration/
     - uses: 8398a7/action-slack@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,12 +11,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.6
-    - name: Install TF 
+    - name: Install TF
       run:  pip install tensorflow==2.4
     - name: Install gretel-synthetics
-      run: pip install -e .
-    - name: Install Test Requirements
-      run: pip install -r test-requirements.txt
+      run: pip install -e .[all,test]
     - name: Lint
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,39 @@
-from setuptools import setup, find_packages
 from os import path
+from pathlib import Path
+
+from setuptools import find_packages, setup
 
 this_dir = path.abspath(path.dirname(__file__))
 
 with open(path.join(this_dir, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-# with open(path.join(this_dir, 'VERSION')) as f:
-#    version = f.read()
 
+def match_prefix(lib, match_list):
+    if not match_list:
+        return False
+    for m in match_list:
+        if lib.strip().startswith(m):
+            return True
+    return False
+
+
+def reqs(file, without=None):
+    with open(Path(__file__).resolve().parent / file) as rf:
+        return [
+            r.strip()
+            for r in rf.readlines()
+            if not (r.startswith("#") or r.startswith("\n"))
+            and not match_prefix(r, without)
+        ]
+
+
+compat_reqs = [
+    'dataclasses==0.7;python_version<"3.7"'
+]
+
+utils_reqs = reqs("utils-requirements.txt")
+test_reqs = reqs("test-requirements.txt")
 
 setup(
     name='gretel-synthetics',
@@ -24,16 +49,12 @@ setup(
     package_dir={'': 'src'},
     packages=find_packages('src'),
     python_requires=">=3.6",
-    install_requires=[
-        'tensorflow_privacy==0.5.1',
-        'sentencepiece==0.1.91',
-        'smart_open>=2.1.0,<3.0',
-        'tqdm<5.0',
-        'pandas>=1.1.0',
-        'numpy>=1.18.0',
-        'dataclasses==0.7;python_version<"3.7"',
-        'loky==2.8.0'
-    ],
+    install_requires=reqs("requirements.txt", without=["tensorflow=="]) + compat_reqs,
+    extras_require={
+        'all': utils_reqs,
+        'utils': utils_reqs,
+        'test': test_reqs
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This updates the setup.py file to pull requirements from txt files. This PR also
* Adds a new `utils` extra to support the new util module
* Adds a `test` extra so we can consolidate dependency management to setuptools when running CI

I was thinking it might be worth following up in a future PR and moving all these requirement files into a `requirements/` directory. We may also consider dropping python 3.6 support. It gave me a bit of a headache resolving scipy deps. It also stops getting security updates in Dec. and Colab is on 3.7 now.