### PR TITLE
Bump required Python version to >=3.7.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install TF
       run:  pip install tensorflow==2.4
     - name: Install gretel-synthetics

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     long_description_content_type="text/markdown",
     package_dir={"": "src"},
     packages=find_packages("src"),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=(
         reqs("requirements.txt", without=["tensorflow==", "torch=="]) + compat_reqs
     ),


### PR DESCRIPTION
Python 3.6 has reached end-of-life on 2021-12-23 (see [PEP 494 – Python 3.6 Release Schedule](https://peps.python.org/pep-0494/)).

All the CI workflows for this package have been already switched to Python 3.7.

The version [0.17.0](https://github.com/gretelai/gretel-synthetics/releases/tag/v0.17.0) is going to be the last version supporting Python 3.6 and will stay available in PyPI.

After this PR is merged, new version will be released which will include this and all other changes that were merged since 0.17.0.