### PR TITLE
Bump python and tensorflow versions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,9 +16,9 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install TF
-      run:  pip install tensorflow==2.4
+      run:  pip install tensorflow==2.8
     - name: Install gretel-synthetics
       run: pip install -e .[all,test]
     - name: Test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,12 +5,15 @@ on: [push]
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.7,3.8,3.9]
     steps:
     - uses: actions/checkout@v1
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python }}
     - name: Install Dependencies
       run:  pip install -r requirements.txt
     - name: Install gretel-synthetics

--- a/setup-utils/setup-gretel-synthetics-tensorflow24-with-gpu.sh
+++ b/setup-utils/setup-gretel-synthetics-tensorflow24-with-gpu.sh
@@ -1,5 +1,5 @@
 #NOTE: Initialize conda (pyenv or virtualenv) before running the script!!!
-#conda create --name tf --yes python=3.8
+#conda create --name tf --yes python=3.9
 #conda activate tf
 
 echo 'Adding NVIDIA package repositories'
@@ -35,7 +35,7 @@ sudo apt-get install -y --no-install-recommends libnvinfer7=7.1.3-1+cuda11.0 \
 
 echo 'Installing tensorflow=2.4 and gretel-synthetics'
 pip3 install --upgrade pip
-pip3 install tensorflow==2.4 gretel-synthetics
+pip3 install tensorflow==2.8 gretel-synthetics
 
 echo 'Check if tensorflow with gpu support is installed'
 python -c "import tensorflow as tf; tf.test.gpu_device_name()"


### PR DESCRIPTION
This bumps integration tests to use python 3.9 and tensorflow 2.8.