### PR TITLE
Add a readthedocs config file to configure the Python version

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Build wheel
       run: |
         pip install wheel

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+formats:
+- pdf
+- epub
+
+python:
+  install:
+  - requirements: docs/requirements.txt


### PR DESCRIPTION
Settings are taken from the current web UI settings. Not sure if we need PDF and ePub, but they are configured atm.

Also found and removed another Python 3.7 reference.