### PR TITLE
update TF 2.8 refs to 2.11

### DIFF
--- a/examples/synthetic_records.ipynb
+++ b/examples/synthetic_records.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "# Google Colab support\n",
     "# Note: Click \"Runtime->Change Runtime Type\" set Hardware Accelerator to \"GPU\"\n",
-    "# Note: Use pip install gretel-synthetics[tf] to install tensorflow if necessary\n",
+    "# Note: Use \"pip install -U gretel-synthetics tensorflow==2.11\" to install Gretel Synthetics and Tensorflow\n",
     "# \n",
     "#!pip install gretel-synthetics --upgrade"
    ]
@@ -105,7 +105,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -119,7 +119,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/setup-utils/setup-gretel-synthetics-tensorflow28-with-gpu.sh
+++ b/setup-utils/setup-gretel-synthetics-tensorflow28-with-gpu.sh
@@ -33,9 +33,9 @@ sudo apt-get install -y --no-install-recommends libnvinfer7=7.1.3-1+cuda11.0 \
     libnvinfer-plugin7=7.1.3-1+cuda11.0
 
 
-echo 'Installing tensorflow=2.8 and gretel-synthetics'
+echo 'Installing tensorflow==2.11 and gretel-synthetics'
 pip3 install --upgrade pip
-pip3 install tensorflow==2.8 gretel-synthetics
+pip3 install tensorflow==2.11 gretel-synthetics
 
 echo 'Check if tensorflow with gpu support is installed'
 python -c "import tensorflow as tf; tf.test.gpu_device_name()"


### PR DESCRIPTION
This updates some references to BYO TF installation to use 2.11. Also removes the `[tf]` extra which isn't supported anymore.